### PR TITLE
Comment spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#ns-flip
+# ns-flip
 A tool for creating and using *updatable* code templates.  Supports regeneration of code without losing custom changes. Framework agnostic.
 
 <a href="https://spectrum.chat/ns-flip">

--- a/src/codeGeneration/handlebars/context/contextForStatic.ts
+++ b/src/codeGeneration/handlebars/context/contextForStatic.ts
@@ -32,7 +32,7 @@ export const contextForStatic = async (
     component: names.component,
   })
 
-  const general = createGeneralInfo(nsInfo, codeDir)
+  const general = await createGeneralInfo(nsInfo, codeDir)
 
   const nsFlipDocumentation = links.DOCUMENTATION
 

--- a/src/codeGeneration/handlebars/context/createGeneralInfo.ts
+++ b/src/codeGeneration/handlebars/context/createGeneralInfo.ts
@@ -12,5 +12,7 @@ export async function createGeneralInfo(nsInfo: NsInfo, codeDir: string) {
     const codePackageJson = await fs.readJson(codePackageJsonPath)
     general.json = codePackageJson
   }
+
+  general.codeDir = codeDir
   return general
 }

--- a/src/templates/loadFileTemplate.ts
+++ b/src/templates/loadFileTemplate.ts
@@ -30,7 +30,7 @@ Handlebars.registerHelper('end', function (locationName: string) {
 Handlebars.registerHelper('custom', function (locationName: string) {
   return new Handlebars.SafeString(
     magicStrings.OPEN_COMMENT_PLACEHOLDER +
-    ` ns__custom_start ${locationName}` +
+    ` ns__custom_start ${locationName} ` +
     magicStrings.CLOSE_COMMENT_PLACEHOLDER + '\n' +
     magicStrings.OPEN_COMMENT_PLACEHOLDER +
     ` ns__custom_end ${locationName} ` +


### PR DESCRIPTION
# Description
Adding a space before the closing delimiter of a `ns__custom_start" comment.  Otherwise, the custom code won't be saved.
