### PR TITLE
Session

### DIFF
--- a/src/codeGeneration/codeBases/createCodeBase.ts
+++ b/src/codeGeneration/codeBases/createCodeBase.ts
@@ -1,4 +1,4 @@
-import {docPages, links, magicStrings} from '../../shared/constants'
+import {commands, docPages, links, magicStrings} from '../../shared/constants'
 
 import {regenerateCode} from '../regenerateCode'
 import {copyTemplateToMeta} from './copyTemplateToMeta'
@@ -14,6 +14,9 @@ export async function createCodeBase(
   const codeMetaDir = `${codeDir}/${magicStrings.META_DIR}`
   const codeTemplateDir = `${codeMetaDir}/${magicStrings.TEMPLATE}`
   const existsCodeTemplateDir = await fs.pathExists(codeTemplateDir)
+  let session = {
+    codeDir,
+  }
 
   if (!templateDir && noSetup) {
     throw new Error('the noSetup flag cannot be used unless a template is specified.')
@@ -39,6 +42,15 @@ export async function createCodeBase(
       `See ${links.DOCUMENTATION}/${docPages.BUILDING_CODE_BASE}.`)
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars,@typescript-eslint/no-empty-function
+  if (templateDir) {
+    const initFunctionFile = `${templateDir}/general/init.ts`
+    if (await fs.pathExists(initFunctionFile)) {
+      const {init} = require(initFunctionFile)
+      session = await init(commands.GENERATE, codeDir)
+    }
+  }
+
   if (templateDir && (!existsCodeTemplateDir || !noSetup)) {
     await createStarterAndNewCode(templateDir, codeDir)
   }
@@ -47,5 +59,5 @@ export async function createCodeBase(
     await copyTemplateToMeta(codeTemplateDir, templateDir)
   }
 
-  await regenerateCode(codeDir)
+  await regenerateCode(codeDir, session)
 }

--- a/src/codeGeneration/codeBases/createCodeBase.ts
+++ b/src/codeGeneration/codeBases/createCodeBase.ts
@@ -52,7 +52,7 @@ export async function createCodeBase(
   }
 
   if (templateDir && (!existsCodeTemplateDir || !noSetup)) {
-    await createStarterAndNewCode(templateDir, codeDir)
+    await createStarterAndNewCode(templateDir, codeDir, session)
   }
 
   if (templateDir) {

--- a/src/codeGeneration/codeBases/createStarterAndNewCode.ts
+++ b/src/codeGeneration/codeBases/createStarterAndNewCode.ts
@@ -27,7 +27,8 @@ async function checkFolder(starterDir: string) {
 
 export async function createStarterAndNewCode(
   templateDir: string,
-  codeDir: string
+  codeDir: string,
+  session: any,
 ) {
   const starterDir = codeDir + suffixes.STARTUP_DIR
   const config: Configuration = await getConfig(templateDir)
@@ -46,7 +47,8 @@ export async function createStarterAndNewCode(
       title: 'Execute Pre-Commands',
       task: async () => {
         if (!preCommands) return
-        return new Listr(preCommandsTaskList(preCommands, starterDir))
+        const preCommandsTasks = preCommandsTaskList(preCommands, starterDir, session).filter(x => x !== null)
+        return new Listr(preCommandsTasks)
       },
     },
     {

--- a/src/codeGeneration/codeBases/settings/specs/askQuestion.ts
+++ b/src/codeGeneration/codeBases/settings/specs/askQuestion.ts
@@ -1,0 +1,25 @@
+import {askForValue} from './askForValue'
+import {replaceGlobalValuesInObject} from './replaceGlobalValuesInObject'
+
+const inquirer = require('inquirer')
+
+export async function askQuestion(
+  subTypeInfo: any,
+  subType: string,
+  answers: any,
+  session: any = {},
+) {
+  const questionKeys = replaceGlobalValuesInObject(subTypeInfo, session, answers)
+  const questions = [
+    askForValue(
+      null,
+      questionKeys,
+      subType,
+      subType,
+    ),
+  ]
+
+  const theseAnswers = await inquirer.prompt(questions)
+  answers = {...answers, ...theseAnswers}
+  return answers
+}

--- a/src/codeGeneration/codeBases/settings/specs/createSpecElement.ts
+++ b/src/codeGeneration/codeBases/settings/specs/createSpecElement.ts
@@ -1,60 +1,12 @@
 import {types} from '../types'
 import {simpleValueEdit} from './simpleValueEdit'
-import {regExObjectValueString} from '../../../../shared/constants/Regex/regExObjectValueString'
-import {askForValue} from './askForValue'
-
-const inquirer = require('inquirer')
-
-const regExObjectValue = new RegExp(regExObjectValueString, 'g')
+import {askQuestion} from './askQuestion'
 
 interface NewSpecElementQuestion {
   type: string;
   name: string;
   message: string;
   validate?: Function;
-}
-
-const globalObjects = {
-  SETTINGS: 'nsInfo',
-  ANSWERS: 'answers',
-  SESSION: 'session',
-  CONFIG: 'config',
-}
-
-async function askQuestion(
-  subTypeInfo: any,
-  subType: string,
-  answers: any,
-  session: any = {},
-) {
-  const subTypeInfoKeys = Object.keys(subTypeInfo)
-  const questionKeys = {...subTypeInfo}
-  subTypeInfoKeys.map((key: string) => {
-    const value = subTypeInfo[key]
-    if ((typeof value) !== 'string') return
-
-    questionKeys[key] = value.replace(regExObjectValue, function (
-      match: string,
-      objectName: string,
-      key: string,
-    ) {
-      if (objectName === globalObjects.ANSWERS) return answers[key]
-      if (objectName === globalObjects.SESSION) return session[key]
-      // if (objectName === globalObjects.SETTINGS) return nsInfo[key]
-    })
-  })
-  const questions = [
-    askForValue(
-      null,
-      questionKeys,
-      subType,
-      subType,
-    ),
-  ]
-
-  const theseAnswers = await inquirer.prompt(questions)
-  answers = {...answers, ...theseAnswers}
-  return answers
 }
 
 export async function createSpecElement(specsForTypeContents: any, session: any = {}) {

--- a/src/codeGeneration/codeBases/settings/specs/replaceGlobalValuesInObject.ts
+++ b/src/codeGeneration/codeBases/settings/specs/replaceGlobalValuesInObject.ts
@@ -1,0 +1,45 @@
+import {regExObjectValueString} from '../../../../shared/constants/Regex/regExObjectValueString'
+
+const regExObjectValue = new RegExp(regExObjectValueString, 'g')
+const globalObjects = {
+  SETTINGS: 'nsInfo',
+  ANSWERS: 'answers',
+  SESSION: 'session',
+  CONFIG: 'config',
+}
+
+function fixBooleans(str: string) {
+  // assumes that a 'true' or 'false' is meant to be a boolean.
+  if (str === 'true') return true
+  if (str === 'false') return false
+  return str
+}
+
+function replaceGlobalObjectValues(value: any, session: any, answers: any) {
+  const newValue = value.replace(regExObjectValue, function (
+    match: string,
+    objectName: string,
+    key: string,
+  ) {
+    if (objectName === globalObjects.ANSWERS) return answers[key]
+    if (objectName === globalObjects.SESSION) return session[key]
+    // if (objectName === globalObjects.SETTINGS) return nsInfo[key]
+  })
+
+  return newValue
+}
+
+export function replaceGlobalValuesInObject(rawObject: any, session: any, answers: any = {}) {
+  const keys = Object.keys(rawObject)
+  const newObject = {...rawObject}
+
+  keys.map((key: string) => {
+    const value = rawObject[key]
+    if ((typeof value) !== 'string') return
+
+    newObject[key] = replaceGlobalObjectValues(value, session, answers)
+    if (value !== newObject[key]) newObject[key] = fixBooleans(newObject[key])
+  })
+
+  return newObject
+}

--- a/src/codeGeneration/codeBases/setup/preCommandsTaskList.ts
+++ b/src/codeGeneration/codeBases/setup/preCommandsTaskList.ts
@@ -1,12 +1,20 @@
 import {CommandSpec} from '../../../shared/constants/types/configuration'
 import {convertCommandArgs} from './convertCommandArgs'
 import {convertCommandOptions} from './convertCommandOptions'
+import {replaceGlobalValuesInObject} from '../settings/specs/replaceGlobalValuesInObject'
 
 const chalk = require('chalk')
 const execa = require('execa')
 
-export function preCommandsTaskList(preCommands: CommandSpec[], starterDir: string) {
-  return preCommands.map((commandSpec: CommandSpec) => {
+export function preCommandsTaskList(
+  preCommands: CommandSpec[],
+  starterDir: string,
+  session: any
+) {
+  const preCommandsInfo = preCommands.map(
+    object => replaceGlobalValuesInObject(object, session, {})).filter(x => !x.prevent)
+
+  return preCommandsInfo.map((commandSpec: CommandSpec) => {
     return {
       title: commandSpec.title,
       task: async () => {

--- a/src/codeGeneration/regenerateCode.ts
+++ b/src/codeGeneration/regenerateCode.ts
@@ -33,7 +33,7 @@ const fs = require('fs-extra')
 //   )
 // }
 
-export async function regenerateCode(codeDir: string) {
+export async function regenerateCode(codeDir: string, session: any) {
   const metaDir = `${codeDir}/${magicStrings.META_DIR}`
   const nsInfo = await getNsInfo(codeDir)
   const starter = `${codeDir}${suffixes.STARTUP_DIR}`
@@ -54,7 +54,7 @@ export async function regenerateCode(codeDir: string) {
     const {general} = config
     let generalSettings = nsInfo.general || {}
 
-    if (Object.keys(generalSettings).length === 0) generalSettings = await createSpecElement(general)
+    if (Object.keys(generalSettings).length === 0) generalSettings = await createSpecElement(general, session)
     nsInfo.general = generalSettings
     await setNsInfo(codeDir, nsInfo)
 

--- a/src/shared/constants/Regex/regExAnswerValueString.ts
+++ b/src/shared/constants/Regex/regExAnswerValueString.ts
@@ -1,3 +1,0 @@
-import {META_DELIMITER} from '..'
-
-export const regExAnswerValueString = META_DELIMITER + 'answers\\.((.|\\.)*)' + META_DELIMITER

--- a/src/shared/constants/Regex/regExObjectValueString.ts
+++ b/src/shared/constants/Regex/regExObjectValueString.ts
@@ -1,0 +1,5 @@
+import {META_DELIMITER} from '..'
+
+const objectName = '[a-zA-Z]+'
+const key = '(.|\\.)*'
+export const regExObjectValueString = META_DELIMITER + `(${objectName})\\.(${key})` + META_DELIMITER

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -102,6 +102,10 @@ export const menuChoices = {
 
 }
 
+export const commands = {
+  GENERATE: 'generate',
+}
+
 export const feedbackForm = {
   URL: 'https://docs.google.com/forms/d/1DooR4toIL-15Ozk6cxB1A8gMJR5e3dntalYAr60PM9Q/formResponse',
   fields: {

--- a/src/shared/constants/types/configuration.ts
+++ b/src/shared/constants/types/configuration.ts
@@ -9,6 +9,7 @@ export interface CommandSpec {
     file: string;
     arguments: string[];
     options?: any;
+    prevent: boolean|Function;
 }
 
 export interface SetupSequence {


### PR DESCRIPTION
# Description
Adds the ability to create an `init` function in a template that sets an object `session`.  The values of `session` are currently available throughout the new spec creation code and the precommands, because those are necessary for the tempate `easy-oclif-cli`.  Should really be expanded to be accessible elsewhere.