### PR TITLE
fixed bug with simple value edits

### DIFF
--- a/src/codeGeneration/codeBases/settings/instances/addStaticInstance.ts
+++ b/src/codeGeneration/codeBases/settings/instances/addStaticInstance.ts
@@ -19,14 +19,20 @@ export async function addStaticInstance(
       name: 'name',
       message: `What is the name of the new ${staticType}?`,
     },
+  ]
+
+  let answers = await inquirer.prompt(addInstanceQuestions)
+
+  const addSlugQuestion = [
     {
       type: 'input',
       name: 'slug',
       message: "What's the slug?  (It will get inserted into things like file names.)",
+      default: answers.name,
     },
   ]
-
-  const answers = await inquirer.prompt(addInstanceQuestions)
+  const answersForSlug = await inquirer.prompt(addSlugQuestion)
+  answers = {...answers, ...answersForSlug}
 
   if (nsInfo.static) {
     if (!nsInfo.static[staticType]) nsInfo.static[staticType] = {}

--- a/src/codeGeneration/codeBases/settings/specs/getQuestionsForSpecSubtree.ts
+++ b/src/codeGeneration/codeBases/settings/specs/getQuestionsForSpecSubtree.ts
@@ -49,9 +49,6 @@ function getChoicesForSpecChildren(
   instanceSpecsSubtree: any,
   type: string,
 ) {
-  // console.log(`** in getChoicesForSpecChildren, type = ${type}`)
-  // console.log(`** in getChoicesForSpecChildren, configSpecsSubtree = ${JSON.stringify(configSpecsSubtree, null, 2)}`)
-  // console.log(`** in getChoicesForSpecChildren, instanceSpecsSubtree = ${JSON.stringify(instanceSpecsSubtree, null, 2)}`)
   let specChildrenChoices: SpecChoice[] = []
 
   if (type === types.LIST) {
@@ -90,16 +87,13 @@ function getChoicesForSpecChildren(
     const subTypes = Object.keys(configSpecsSubtree)
     specChildrenChoices = subTypes.map((subTypeName: string) => {
       const configSpecsSubtreeElement = configSpecsSubtree[subTypeName]
-      // console.log(`** configSpecsSubtreeElement= ${JSON.stringify(configSpecsSubtreeElement, null, 1)}`)
       const instanceSpecsSubtreeElement = instanceSpecsSubtree[subTypeName]
-      // console.log(`** instanceSpecsSubtreeElement= ${JSON.stringify(instanceSpecsSubtreeElement, null, 1)}`)
       return answerForSpecificSubtype(
         subTypeName,
         configSpecsSubtreeElement,
         instanceSpecsSubtreeElement
       )
     })
-    // console.log(`** specChildrenChoices = ${JSON.stringify(specChildrenChoices, null, 2)}`)
   }
 
   specChildrenChoices.push({

--- a/src/codeGeneration/codeBases/settings/specs/updateSpecSubtree.ts
+++ b/src/codeGeneration/codeBases/settings/specs/updateSpecSubtree.ts
@@ -68,8 +68,20 @@ export async function updateSpecSubtree(
   required: boolean,
 ) {
   try {
-    if (!specsForInstance)
+    // if a set or list has no value, create the element
+    if (!specsForInstance && (type in [types.SET, types.LIST, types.TOP_LEVEL])) {
       specsForInstance = await createSpecElement(specsForType)
+    }
+
+    /*
+      This while loop is central to the settings process.  There can be a few
+      levels handled here:
+          (1) a control step, meaning deciding navigation;
+          (2) actually prompting for a value.
+      'TO_EDIT' is set for the first, and 'EDIT' for the second.  They are mutually exclusive,
+      so this is poorly done.
+      TODO: refactor this to have a separate function for each.
+     */
 
     // eslint-disable-next-line no-constant-condition
     while (true) {
@@ -81,10 +93,10 @@ export async function updateSpecSubtree(
         required)
       const answers: AnswersForStaticInstanceSpec = await inquirer.prompt(questions)
 
+      if (answers[EDIT] !== undefined) return simpleValueEdit(type, answers[EDIT])
+
       if (answers[TO_EDIT] && answers[TO_EDIT].name === DONE) return specsForInstance
       if (answers[TO_EDIT] && answers[TO_EDIT].name === DELETE) return undefined
-
-      if (answers[EDIT] !== undefined) return simpleValueEdit(type, answers[EDIT])
 
       if (answers[EDIT_OPTIONS] && answers[EDIT_OPTIONS] === editOptions.DELETE)
         return null


### PR DESCRIPTION
# Description
`updateSpecsSubtree` now only calls createSpecElement for a set or list.  So when a simple edit for settings is needed, it is handled correctly.

Fixes # (issue)
Simple edits were not working

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
