### PR TITLE
offer to regenerate after updating settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1748,6 +1748,11 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "deep-object-diff": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/deep-object-diff/-/deep-object-diff-1.1.0.tgz",
+      "integrity": "sha512-b+QLs5vHgS+IoSNcUE4n9HP2NwcHj7aqnJWsjPtuG75Rh5TOaGt0OjAYInh77d5T16V5cRDC+Pw/6ZZZiETBGw=="
+    },
     "default-require-extensions": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "arr-diff": "^4.0.0",
     "chalk": "^4.1.0",
     "currencyformatter.js": "^1.0.4",
+    "deep-object-diff": "^1.1.0",
     "dir-compare": "^2.4.0",
     "execa": "^4.0.3",
     "expand-tilde": "^2.0.2",

--- a/src/codeGeneration/codeBases/settings/settingsMenu.ts
+++ b/src/codeGeneration/codeBases/settings/settingsMenu.ts
@@ -1,0 +1,69 @@
+import {Configuration} from '../../../shared/constants/types/configuration'
+import {NsInfo} from '../../../shared/constants/types/nsInfo'
+import {exitOption, menuOption} from '../../../shared/constants/chalkColors'
+import {DONE, types} from './types'
+import {staticSettings} from './staticSettings'
+import {updateSpecSubtree} from './specs/updateSpecSubtree'
+import {setNsInfo} from '../../../shared/nsFiles/setNsInfo'
+
+const inquirer = require('inquirer')
+const settingsTypes =
+    {
+      GENERAL: 'general',
+      STATIC: 'static',
+      DYNAMIC: 'dynamic',
+    }
+const SETTINGS_TYPE = 'settingsType'
+const questions = [{
+  type: 'list',
+  name: SETTINGS_TYPE,
+  message: 'What settings would you like to change?',
+  choices: [
+    {
+      name: menuOption('General'),
+      value: settingsTypes.GENERAL,
+      short: 'General',
+    },
+    {
+      name: menuOption('Static'),
+      value: settingsTypes.STATIC,
+      short: 'Static',
+    },
+    {
+      name: exitOption('Quit'),
+      value: DONE,
+      short: 'quit',
+    },
+  ],
+}]
+
+export async function settingsMenu(
+  config: Configuration,
+  nsInfo: NsInfo,
+  codeDir: string,
+) {
+  try {
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const answers = await inquirer.prompt(questions)
+      if (answers[SETTINGS_TYPE] === DONE) {
+        return nsInfo
+      }
+      if (answers[SETTINGS_TYPE] === settingsTypes.STATIC) await staticSettings(config, nsInfo, codeDir)
+      if (answers[SETTINGS_TYPE] === settingsTypes.GENERAL) {
+        const nsInfoGeneral = await updateSpecSubtree(
+          nsInfo.general,
+          config.general,
+          types.TOP_LEVEL,
+          'general settings',
+          true,
+        )
+
+        nsInfo.general = nsInfoGeneral
+        await setNsInfo(codeDir, nsInfo)
+      }
+    }
+  } catch (error) {
+    throw new Error(`in settings menu: ${error}`)
+  }
+}


### PR DESCRIPTION
# Description
Updates the settings command to:
1. record the initial value of settings
2. compare it to the updated version after a user quits.
3. if they are different, offer to regenerate.

Fixes # 91

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Standard tests and simple trial