### PR TITLE
changed order of generation to copy over template first

### DIFF
--- a/src/codeGeneration/codeBases/copyTemplateToMeta.ts
+++ b/src/codeGeneration/codeBases/copyTemplateToMeta.ts
@@ -6,6 +6,7 @@ const fs = require('fs-extra')
 export async function copyTemplateToMeta(codeTemplateDir: string, templateDir: string) {
   if (codeTemplateDir === templateDir) return
   try {
+    await fs.ensureDir(codeTemplateDir)
     await fs.emptyDir(codeTemplateDir)
     // copyProjectDirectory(templateDir, codeTemplateDir)
     await fs.copy(templateDir, codeTemplateDir)

--- a/src/codeGeneration/codeBases/createCodeBase.ts
+++ b/src/codeGeneration/codeBases/createCodeBase.ts
@@ -44,7 +44,8 @@ export async function createCodeBase(
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars,@typescript-eslint/no-empty-function
   if (templateDir) {
-    const initFunctionFile = `${templateDir}/general/init.ts`
+    await copyTemplateToMeta(codeTemplateDir, templateDir)
+    const initFunctionFile = `${codeTemplateDir}/general/init.ts`
     if (await fs.pathExists(initFunctionFile)) {
       const {init} = require(initFunctionFile)
       session = await init(commands.GENERATE, codeDir)
@@ -53,10 +54,6 @@ export async function createCodeBase(
 
   if (templateDir && (!existsCodeTemplateDir || !noSetup)) {
     await createStarterAndNewCode(templateDir, codeDir, session)
-  }
-
-  if (templateDir) {
-    await copyTemplateToMeta(codeTemplateDir, templateDir)
   }
 
   await regenerateCode(codeDir, session)

--- a/src/codeGeneration/codeBases/createNewCode.ts
+++ b/src/codeGeneration/codeBases/createNewCode.ts
@@ -4,7 +4,6 @@ import {errorMessage} from '../../shared/errorMessage'
 // import {copyTemplateToMeta} from './copyTemplateToMeta'
 
 const chalk = require('chalk')
-const execa = require('execa')
 const fs = require('fs-extra')
 const Listr = require('listr')
 
@@ -29,24 +28,13 @@ export async function createNewCode(
       task: async () => {
         const finalCodeDir = await getCodeDir(codeDir) || ''
 
-        await execa(
-          'cp',
-          ['-r', starterDir, finalCodeDir],
-        ).catch(
+        await fs.copy(starterDir, finalCodeDir).catch(
           (error: any) => {
             throw new Error(`${chalk.red(`error copying over from ${starterDir}.`)} Here is the error reported:\n${error}`)
           },
         )
       },
     },
-    // {
-    //   title: 'Copy template to dir',
-    //   task: async () => {
-    //     const codeMetaDir = `${codeDir}/${magicStrings.META_DIR}`
-    //     const codeTemplateDir = `${codeMetaDir}/${magicStrings.TEMPLATE}`
-    //     await copyTemplateToMeta(codeTemplateDir, templateDir)
-    //   },
-    // },
   ])
   return tasksCopyFromBaseApp
 }

--- a/src/codeGeneration/codeBases/createStarterAndNewCode.ts
+++ b/src/codeGeneration/codeBases/createStarterAndNewCode.ts
@@ -1,5 +1,5 @@
 import {installDevPackagesTaskList} from './setup/installDevPackagesTaskList'
-import {docPages, links, magicStrings, suffixes} from '../../shared/constants'
+import {dirNames, docPages, fileNames, links, magicStrings, suffixes} from '../../shared/constants'
 import {Configuration} from '../../shared/constants/types/configuration'
 import {getConfig} from '../../shared/configs/getConfig'
 import {CustomCodeRepository} from '../../shared/constants/types/custom'
@@ -112,7 +112,9 @@ export async function createStarterAndNewCode(
   try {
     await setup.run()
     await installDependencies.run()
-    if (!await fs.pathExists(codeDir)) {
+    const nsFilePath = `${codeDir}/${magicStrings.META_DIR}/${magicStrings.NS_FILE}`
+    if (!await fs.pathExists(nsFilePath)) {
+      // if the settings file doesn't exist yet then it's brand new...
       const newAppTasks = await createNewCode(codeDir, starterDir)// , finalTemplateDir)
       await newAppTasks.run()
     }

--- a/src/codeGeneration/codeBases/createStarterAndNewCode.ts
+++ b/src/codeGeneration/codeBases/createStarterAndNewCode.ts
@@ -1,5 +1,5 @@
 import {installDevPackagesTaskList} from './setup/installDevPackagesTaskList'
-import {dirNames, docPages, fileNames, links, magicStrings, suffixes} from '../../shared/constants'
+import {docPages, links, magicStrings, suffixes} from '../../shared/constants'
 import {Configuration} from '../../shared/constants/types/configuration'
 import {getConfig} from '../../shared/configs/getConfig'
 import {CustomCodeRepository} from '../../shared/constants/types/custom'

--- a/src/inputs/getCodeDir.ts
+++ b/src/inputs/getCodeDir.ts
@@ -1,31 +1,10 @@
-import {codeNameFromPath} from './codeNameFromPath'
-
 import {promptTypes, promptUser} from './promptUser'
-
-const fs = require('fs-extra')
-
-const testCodeDir = async (codeDir: string) => {
-  const appName = codeNameFromPath(codeDir)
-  if (!codeDir || appName.length === 0)
-    return 'Your directory is missing for your app.  Please enter a path and a final directory name (all numbers and lowercase letters, no spaces).'
-
-  const upperCaseCheck = /(.*[A-Z].*)/
-  if (upperCaseCheck.test(codeDir))
-    return `The appName '${appName}' contains at least one capital, which create-react-app does not permit.  Please enter a new path...`
-
-  if (await fs.pathExists(codeDir))
-    return `There already exists a directory ${codeDir}.  Either delete the directory and try again or give a new name.  Please enter a path again...`
-
-  return ''
-}
+import {testCodeDir} from '../shared/testCodeDir'
 
 export async function getCodeDir(codeDir: string | undefined) {
-  let prompt = 'Please enter a path for your app.  The actual directory of the app must be all numbers and lowercase letters, with no spaces.'
-  if (codeDir) {
-    prompt = await testCodeDir(codeDir)
-  }
-  if (prompt.length === 0) return codeDir
+  if (codeDir) return codeDir
 
+  const prompt = 'Please enter a path for your app.  The actual directory of the app must be all numbers and lowercase letters, with no spaces.'
   return promptUser(
     'codeDir',
     promptTypes.TEXT,

--- a/src/shared/testCodeDir.ts
+++ b/src/shared/testCodeDir.ts
@@ -1,0 +1,17 @@
+import {codeNameFromPath} from '../inputs/codeNameFromPath'
+
+const fs = require('fs-extra')
+export const testCodeDir = async (codeDir: string) => {
+  const appName = codeNameFromPath(codeDir)
+  if (!codeDir || appName.length === 0)
+    return 'Your directory is missing for your app.  Please enter a path and a final directory name (all numbers and lowercase letters, no spaces).'
+
+  const upperCaseCheck = /(.*[A-Z].*)/
+  if (upperCaseCheck.test(codeDir))
+    return `The appName '${appName}' contains at least one capital, which create-react-app does not permit.  Please enter a new path...`
+
+  if (await fs.pathExists(codeDir))
+    return `There already exists a directory ${codeDir}.  Either delete the directory and try again or give a new name.  Please enter a path again...`
+
+  return ''
+}


### PR DESCRIPTION
# Description
Have the template copied over, then use that template for the initial generation.  Note that you also need to include in the template itself any node modules needed for the init() function.

Fixes #96 

## Type of change
