### PR TITLE
install template packages

### DIFF
--- a/src/codeGeneration/codeBases/copyTemplateToMeta.ts
+++ b/src/codeGeneration/codeBases/copyTemplateToMeta.ts
@@ -1,4 +1,4 @@
-// import execa = require('execa');
+import execa = require('execa');
 
 const chalk = require('chalk')
 const fs = require('fs-extra')
@@ -10,6 +10,14 @@ export async function copyTemplateToMeta(codeTemplateDir: string, templateDir: s
     await fs.emptyDir(codeTemplateDir)
     // copyProjectDirectory(templateDir, codeTemplateDir)
     await fs.copy(templateDir, codeTemplateDir)
+    const templatePackageJsonPath = `${codeTemplateDir}/package.json`
+    if (await fs.pathExists(templatePackageJsonPath)) {
+      await execa(
+        'npm',
+        ['install'],
+        {cwd: codeTemplateDir}
+      )
+    }
     // , {
     //   filter: function (path: any) {
     //     return path.indexOf('node_modules') <= -1

--- a/src/codeGeneration/codeBases/createNewCode.ts
+++ b/src/codeGeneration/codeBases/createNewCode.ts
@@ -1,7 +1,5 @@
 import {getCodeDir} from '../../inputs/getCodeDir'
 import {errorMessage} from '../../shared/errorMessage'
-// import {magicStrings} from '../constants'
-// import {copyTemplateToMeta} from './copyTemplateToMeta'
 
 const chalk = require('chalk')
 const fs = require('fs-extra')


### PR DESCRIPTION
# Description
Adding a call to `npm install` when copying over a template to meta if there is a package.json file

Fixes #98 